### PR TITLE
change create object class name RefreshToken to JwtBearer

### DIFF
--- a/src/controllers/TokenController.php
+++ b/src/controllers/TokenController.php
@@ -109,7 +109,7 @@ class TokenController extends Controller
                 break;
             case 'urn:ietf:params:oauth:grant-type:jwt-bearer':
                 $grantIsValid = true;
-                $oauthGrantType = Yii::createObject('OAuth2\GrantType\RefreshToken');
+                $oauthGrantType = Yii::createObject('OAuth2\GrantType\JwtBearer');
                 /* @var \OAuth2\GrantType\JwtBearer $oauthGrantType */
                 $oauthServer->addGrantType($oauthGrantType);
                 break;


### PR DESCRIPTION
on JWT Bearer  maybe i think is it a grant type `OAuth2\GrantType\JwtBearer` ?

ref: http://bshaffer.github.io/oauth2-server-php-docs/grant-types/jwt-bearer/