### PR TITLE
Use database specified in module config when deleting expired tokens

### DIFF
--- a/src/services/mySql/AccessTokenService.php
+++ b/src/services/mySql/AccessTokenService.php
@@ -354,7 +354,7 @@ class AccessTokenService extends BaseService implements AccessTokenServiceInterf
         $accessTokens = (new Query())->select('*')
             ->from($this->accessTokensTable)
             ->where('expiry < :date', [':date' => date('Y-m-d H:i:s')])
-            ->all();
+            ->all($this->db);
         foreach ($accessTokens as $accessTokenQuery) {
             $accessToken = $this->findOne($accessTokenQuery['id']);
             if ($accessToken instanceof AccessTokenModelInterface) {

--- a/src/services/mySql/JtiService.php
+++ b/src/services/mySql/JtiService.php
@@ -299,7 +299,7 @@ class JtiService extends BaseService implements JtiServiceInterface
         $jtis = (new Query())->select('*')
             ->from($this->jtisTable)
             ->where('expires < :date', [':date' => date('Y-m-d H:i:s')])
-            ->all();
+            ->all($this->db);
         foreach ($jtis as $jtiQuery) {
             $jti = $this->findOne($jtiQuery['id']);
             if ($jti instanceof JtiModelInterface) {

--- a/src/services/mySql/RefreshTokenService.php
+++ b/src/services/mySql/RefreshTokenService.php
@@ -358,7 +358,7 @@ class RefreshTokenService extends BaseService implements RefreshTokenServiceInte
         $refreshTokens = (new Query())->select('*')
             ->from($this->refreshTokensTable)
             ->where('expiry < :date', [':date' => date('Y-m-d H:i:s')])
-            ->all();
+            ->all($this->db);
         foreach ($refreshTokens as $refreshTokenQuery) {
             $refreshToken = $this->findOne($refreshTokenQuery['id']);
             if ($refreshToken instanceof RefreshTokenModelInterface) {


### PR DESCRIPTION
Hi pgaultier,

thanks for the amazing code. However the deleteAllExpired functions of the MySQL service still use the default database, not the one specified in the module config.